### PR TITLE
Extract the tarball path from the 'helm package' output

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -78,7 +78,7 @@ jobs:
           - name: Build Helm Chart
             id: build-chart
             run: |
-              chart_tarball=$(helm package ${{matrix.chartpath}})
+              chart_tarball=$(helm package ${{matrix.chartpath}} | awk '{print $NF}')
               echo "tarball=${chart_tarball}" >> "$GITHUB_OUTPUT"
 
           - name: Push Helm chart

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -78,7 +78,14 @@ jobs:
           - name: Build Helm Chart
             id: build-chart
             run: |
-              chart_tarball=$(helm package ${{matrix.chartpath}} | awk '{print $NF}')
+              # Extract tarball name from a line that looks like
+              # Successfully packaged chart and saved it to: /home/blin/vcs/images/osg-helm-charts/supported/osg-htc/osdf-origin/osdf-origin-0.29.tgz
+              helm_package_success_message=$(helm package ${{matrix.chartpath}} | grep -m1 '^Success')
+              chart_tarball=${helm_package_success_message#*': '}  # delete up to and including ': '
+              if [[ ! $chart_tarball ]]; then
+                  echo "helm package failed" >&2
+                  exit 1
+              fi
               echo "tarball=${chart_tarball}" >> "$GITHUB_OUTPUT"
 
           - name: Push Helm chart


### PR DESCRIPTION
Output of `helm package` looks like:

```
blin@blin-work:~/vcs/images/osg-helm-charts/supported/osg-htc/osdf-origin (test-publish)$ helm package .
Successfully packaged chart and saved it to: /home/blin/vcs/images/osg-helm-charts/supported/osg-htc/osdf-origin/osdf-origin-0.29.tgz
```

Alternatively, we can specify the destination dir with `-d`  but then we're still stuck constructing the name of the tarball 🙄 