### PR TITLE
Scrub Unix username for generated Hosted CE config (SOFTWARE-5596)

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.5.0
+version: 4.5.1
 

--- a/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
@@ -77,7 +77,8 @@ data:
     # Templatize IDTOKEN generation for glidein -> CE collector advertising (SOFTWARE-5556)
     {{- range $index, $map := .Values.SciTokenRemoteUserMapping }}
     {{- range $url, $user := $map }}
-    JOB_ROUTER_CREATE_IDTOKEN_{{ $user }} @=end
+    # N.B. Special chars in a helm template regex need to be escaped with '\\'
+    JOB_ROUTER_CREATE_IDTOKEN_{{ mustRegexReplaceAll "[\\.-]" "$user" "_" }} @=end
       sub = "{{ $user }}@users.htcondor.org"
       kid = "POOL"
       lifetime = 604800

--- a/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
@@ -78,7 +78,7 @@ data:
     {{- range $index, $map := .Values.SciTokenRemoteUserMapping }}
     {{- range $url, $user := $map }}
     # N.B. Special chars in a helm template regex need to be escaped with '\\'
-    JOB_ROUTER_CREATE_IDTOKEN_{{ mustRegexReplaceAll "[\\.-]" "$user" "_" }} @=end
+    JOB_ROUTER_CREATE_IDTOKEN_{{ mustRegexReplaceAll "[^A-Za-z0-9_]" "$user" "_" }} @=end
       sub = "{{ $user }}@users.htcondor.org"
       kid = "POOL"
       lifetime = 604800


### PR DESCRIPTION
From
https://helm.sh/docs/chart_template_guide/function_list/#regexreplaceall-mustregexreplaceall

> regexReplaceAll, mustRegexReplaceAll
>
> Returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement. Inside string replacement, $ signs are interpreted as in Expand, so for instance $1 represents the text of the first submatch
>
>     regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W"
>
> The above produces -W-xxW-
>
> regexReplaceAll panics if there is a problem and mustRegexReplaceAll returns an error to the template engine if there is a problem.