### PR TITLE
Add NetworkPolicy and CertManager to the osdf-origin (SOFTWARE-5625)

### DIFF
--- a/supported/osg-htc/osdf-origin/Chart.yaml
+++ b/supported/osg-htc/osdf-origin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: osdf-origin
 # Chart version
-version: "0.30"
+version: "0.31"
 description: OSDF origin
 # Version of application packaged for installation; this should be the branch the xcache RPM is from
 appVersion: "V3"

--- a/supported/osg-htc/osdf-origin/templates/certificate.yaml
+++ b/supported/osg-htc/osdf-origin/templates/certificate.yaml
@@ -1,0 +1,14 @@
+---
+{{ if .Values.certmanager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "osdf-origin.fullname" . }}
+spec:
+  secretName: {{ template "osdf-origin.name"}}-cert
+  dnsNames:
+  - {{ .Values.topologyFQDN }}
+  issuerRef:
+    name: letsencrypt-prod-newchain
+    kind: ClusterIssuer
+{{ end }}

--- a/supported/osg-htc/osdf-origin/templates/deployment.yaml
+++ b/supported/osg-htc/osdf-origin/templates/deployment.yaml
@@ -66,10 +66,14 @@ spec:
         {{- end }}
         {{- end }}
 
-        {{- if .Values.hostCertKeySecret }}
+        {{- if or .Values.certmanager.enabled .Values.hostCertKeySecret }}
         - name: hostcertkey
           secret:
+            {{- if .Values.certmanager.enabled }}
+            secretName: {{ template "osdf-origin.name"}}-cert
+            {{- else if .Values.hostCertKeySecret }}
             secretName: {{ .Values.hostCertKeySecret }}
+            {{- end }}
             items:
             - key: tls.crt
               path: hostcert.pem
@@ -180,7 +184,7 @@ spec:
             - mountPath: /xcache/namespace{{ .mountPath }}
               name: {{ .name }}
             {{ end }}
-            {{- if .Values.hostCertKeySecret }}
+            {{- if or .Values.certmanager.enabled .Values.hostCertKeySecret }}
             - mountPath: /etc/grid-security/hostcert.pem
               name: hostcertkey
               subPath: hostcert.pem

--- a/supported/osg-htc/osdf-origin/templates/networkpolicy.yaml
+++ b/supported/osg-htc/osdf-origin/templates/networkpolicy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-{{ template "osdf-origin.name" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "osdf-origin.name" . }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        # stash-origin
+        - protocol: TCP
+          port: 1094
+          # stash-origin-auth
+        - protocol: TCP
+          port: 1095
+  # egress is needed for downloading CRLs, contacting the OSG Central
+  # Collector, reporting to the OSG redirctor
+  egress:
+    - {}

--- a/supported/osg-htc/osdf-origin/values.yaml
+++ b/supported/osg-htc/osdf-origin/values.yaml
@@ -8,7 +8,12 @@ fullnameOverride: ""
 topologyResourceName: "TestOrigin"
 topologyFQDN: "testorigin.example.net"
 
-# run 'slate secret create --help' for usage
+# Use CertManager for the OSDF Origin host cert
+certmanager:
+  enabled: false
+  issuerName: null
+
+# If not using CertManager, you must provide a host certificate as a secret
 # hostCertKeySecret is the name of the secret containing a host key and certificate in
 # "tls.key" and "tls.crt", respectively.
 hostCertKeySecret: null


### PR DESCRIPTION
With the current setup I don't think we have a 1:1 relationship between network policies and pods. Moving it into the Helm chart makes it so that we don't have to worry about it.

We should consider doing this for the Hosted CE, too