### PR TITLE
All hail SemVer (SOFTWARE-5625)

### DIFF
--- a/supported/osg-htc/osdf-origin/Chart.yaml
+++ b/supported/osg-htc/osdf-origin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: osdf-origin
 # Chart version
-version: "0.31"
+version: "0.31.0"
 description: OSDF origin
 # Version of application packaged for installation; this should be the branch the xcache RPM is from
 appVersion: "V3"


### PR DESCRIPTION
If charts don't conform to SemVer, helm will fail pulls from an OCI repo with the following:

     Error: Unable to locate any tags in provided repository: oci://...