### PR TITLE
Helm chart bugfixes

### DIFF
--- a/supported/osg-htc/osdf-origin/Chart.yaml
+++ b/supported/osg-htc/osdf-origin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: osdf-origin
 # Chart version
-version: "0.31.0"
+version: "0.31.1"
 description: OSDF origin
 # Version of application packaged for installation; this should be the branch the xcache RPM is from
 appVersion: "V3"

--- a/supported/osg-htc/osdf-origin/templates/certificate.yaml
+++ b/supported/osg-htc/osdf-origin/templates/certificate.yaml
@@ -9,6 +9,6 @@ spec:
   dnsNames:
   - {{ .Values.topologyFQDN }}
   issuerRef:
-    name: letsencrypt-prod-newchain
+    name: {{ .Values.certmanager.issuerName }}
     kind: ClusterIssuer
 {{ end }}

--- a/supported/osg-htc/osdf-origin/templates/certificate.yaml
+++ b/supported/osg-htc/osdf-origin/templates/certificate.yaml
@@ -5,7 +5,7 @@ kind: Certificate
 metadata:
   name: {{ include "osdf-origin.fullname" . }}
 spec:
-  secretName: {{ template "osdf-origin.name"}}-cert
+  secretName: {{ template "osdf-origin.name" . }}-cert
   dnsNames:
   - {{ .Values.topologyFQDN }}
   issuerRef:

--- a/supported/osg-htc/osdf-origin/templates/deployment.yaml
+++ b/supported/osg-htc/osdf-origin/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - name: hostcertkey
           secret:
             {{- if .Values.certmanager.enabled }}
-            secretName: {{ template "osdf-origin.name"}}-cert
+            secretName: {{ template "osdf-origin.name" . }}-cert
             {{- else if .Values.hostCertKeySecret }}
             secretName: {{ .Values.hostCertKeySecret }}
             {{- end }}


### PR DESCRIPTION
We may want to consider a "test" dir that contains various `values.yaml` files that test the various templating paths, e.g. `certmanager.enabled: true`