### PR TITLE
Adds BoscoOverrideDir as a value for hosted-ce

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.6.1
+version: 4.6.2

--- a/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
@@ -292,7 +292,7 @@ spec:
         - name: BOSCO_GIT_ENDPOINT
           value: {{ .Values.BoscoOverrides.GitEndpoint }}
         - name: BOSCO_DIRECTORY
-          value: {{ .Values.Topology.Resource }}
+          value: {{ .Values.BoscoOverrides.BoscoOverrideDir | default .Values.Topology.Resource }}
         {{ end }}
         {{  if not .Values.Persistence.LibCondorCeVolume }}
         lifecycle:

--- a/supported/osg-htc/osg-hosted-ce/values.yaml
+++ b/supported/osg-htc/osg-hosted-ce/values.yaml
@@ -154,10 +154,12 @@ Persistence:
   LibCondorCeVolume: null
 
 # Options to allow override of the bosco directory from arbitrary git repos
-# Bosco override dirs are expected in the following location in the git repo:
+# Bosco override dir lets you set what directory you want to put your bosco
+# overrides in. That field will default to the following location in the git repo:
 #   <RESOURCE NAME>/bosco_override/
 BoscoOverrides:
   Enabled: false
+  BoscoOverrideDir: null
   GitEndpoint: https://github.com/slateci/bosco-override-template
   # If GitEndpoint requires authentication, create a SLATE secret with
   # 'git.key' containing the private SSH key that can access


### PR DESCRIPTION
Need this because project folder structure for osg-hosted-ce has changed Have cluttered folders that only exist for the bosco_overrides