### PR TITLE
Fix monitor rendering

### DIFF
--- a/supported/osg-htc/osdf-origin/Chart.yaml
+++ b/supported/osg-htc/osdf-origin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: osdf-origin
 # Chart version
-version: "0.31.2"
+version: "0.31.3"
 description: OSDF origin
 # Version of application packaged for installation; this should be the branch the xcache RPM is from
 appVersion: "V3"

--- a/supported/osg-htc/osdf-origin/templates/deployment.yaml
+++ b/supported/osg-htc/osdf-origin/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             type: Directory
           {{- else if .cephfs }}
           cephfs:
-            monitors: {{ .cephfs.monitors }}
+            monitors: {{ toJson .cephfs.monitors }}
             user: {{ .cephfs.user }}
             secretRef:
               name: {{ .cephfs.secretRef.name }}


### PR DESCRIPTION
When we specify CephFS monitors in a list of items in the values YAML, it gets incorrectly rendered into a space-separated list of devices that are passed into the mount(8) command.

i.e., this:
```    cephfs:
      monitors:
        - "192.168.231.138:6789"
        - "192.168.231.139:6789"
        - "192.168.231.140:6789"
```

renders to this:
 ```
          cephfs:
            monitors: [192.168.231.138:6789 192.168.231.139:6789 192.168.231.140:6789]
```

I assume this is something to do with Helm using the Go templating engine. 

Adding `toJson` to the template seems to fix this (thanks @matyasselmeci )