### PR TITLE
Add missing ceph mount options

### DIFF
--- a/supported/osg-htc/osdf-origin/Chart.yaml
+++ b/supported/osg-htc/osdf-origin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: osdf-origin
 # Chart version
-version: "0.31.3"
+version: "0.32.0"
 description: OSDF origin
 # Version of application packaged for installation; this should be the branch the xcache RPM is from
 appVersion: "V3"

--- a/supported/osg-htc/osdf-origin/templates/deployment.yaml
+++ b/supported/osg-htc/osdf-origin/templates/deployment.yaml
@@ -60,6 +60,12 @@ spec:
             user: {{ .cephfs.user }}
             secretRef:
               name: {{ .cephfs.secretRef.name }}
+            {{- if .cephfs.path }}
+            path: {{ .cephfs.path }}
+            {{- end }}
+            {{- if .cephfs.readOnly }}
+            readOnly: {{ .cephfs.readOnly }}
+            {{- end }}
           {{- else }}
             {{- fail "Specify claimName, hostPath, or cephfs" -}}
           {{- end }}


### PR DESCRIPTION
We add two missing ceph mount options from the cephfs example. 

`path: "/some/path"` indicates the root of the device's mount. Default is `/` if not specified.
`readOnly: <bool>` indicates whether or not the filesystem should be read only. Default is `false` if not specified. 