### PR TITLE
HTCONDOR-2253  Add new Job Router syntax equivalent to old syntax

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.6.3
+version: 4.7.0

--- a/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
@@ -130,6 +130,34 @@ data:
     JOB_ROUTER_ENTRIES = [Name = "Hosted_CE_default_route"]
 
     JOB_ROUTER_ROUTE_NAMES = Hosted_CE_default_route
+
+    # New Job Router transforms for token and GridResource construction
+    JOB_ROUTER_TRANSFORM_Token @=jrt
+        SET TransferInput "$(MY.TransferInput),/usr/share/condor-ce/glidein-tokens/$(MY.Owner)/ce_$(MY.Owner).idtoken"
+    @jrt
+    JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES) Token
+
+    JOB_ROUTER_TRANSFORM_GridResource @=jrt
+        grid_resource = batch {{ .Values.RemoteCluster.Batch }} $(MY.Owner)@{{ .Values.RemoteCluster.LoginHost }}
+        grid_resource = $(grid_resource) --rgahp-glite ~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite
+        {{ if .Values.BoscoOverrides.TarballURL | default "" | contains "bosco-1.3"  }}
+        grid_resource = $(grid_resource) --rgahp-script batch_gahp
+        {{ end }}
+        {{ if not .Values.RemoteCluster.SSHBatchMode }}
+        grid_resource = $(grid_resource) --rgahp-nobatchmode
+        {{ end }}
+        {{ if not .Values.RemoteCluster.LoginShell }}
+        grid_resource = $(grid_resource) --rgahp-nologin
+        {{ end }}
+    @jrt
+    JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) GridResource
+
+    # To use the new Job Router syntax, uncomment these lines:
+    #JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False
+    #JOB_ROUTER_ROUTE_Hosted_CE_default_route @=jrt
+    #    GridResource = "$(grid_resource)"
+    #@jrt
+
     # Operator-provided HTCondor-CE configuration below this line
 {{ .Values.HTCondorCeConfig | default "" | indent 4 }}
 ---

--- a/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
@@ -152,11 +152,14 @@ data:
     @jrt
     JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) GridResource
 
-    # To use the new Job Router syntax, uncomment these lines:
-    #JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False
-    #JOB_ROUTER_ROUTE_Hosted_CE_default_route @=jrt
-    #    GridResource = "$(grid_resource)"
-    #@jrt
+    {{ if .Values.JobRouterUseTransforms }}
+    JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False
+    JOB_ROUTER_ROUTE_Hosted_CE_default_route @=jrt
+        GridResource = "$(grid_resource)"
+    @jrt
+    {{ else }}
+    JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = True
+    {{ end }}
 
     # Operator-provided HTCondor-CE configuration below this line
 {{ .Values.HTCondorCeConfig | default "" | indent 4 }}

--- a/supported/osg-htc/osg-hosted-ce/values.yaml
+++ b/supported/osg-htc/osg-hosted-ce/values.yaml
@@ -226,6 +226,9 @@ Debug:
 Developer:
   Enabled: false
 
+# Should the Job Router use the new route syntax?
+JobRouterUseTransforms: false
+
 ### SLATE-START ###
 SLATE:
   Instance:


### PR DESCRIPTION
In 90-instance.conf, add route transform rules for transferring tokens and setting GridResource in the new Job Router syntax that's equivalent to what's already done in the old syntax.
The old syntax is still what's used, but CEs should now be able to opt into using the new syntax.