### PR TITLE
HTCONDOR-2253 Fix setting of GridResource in new route syntax

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.7.0
+version: 4.7.1

--- a/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
@@ -138,16 +138,16 @@ data:
     JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES) Token
 
     JOB_ROUTER_TRANSFORM_GridResource @=jrt
-        grid_resource = batch {{ .Values.RemoteCluster.Batch }} $(MY.Owner)@{{ .Values.RemoteCluster.LoginHost }}
-        grid_resource = $(grid_resource) --rgahp-glite ~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite
+        gr = batch {{ .Values.RemoteCluster.Batch }} $(MY.Owner)@{{ .Values.RemoteCluster.LoginHost }}
+        gr = $(gr) --rgahp-glite ~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite
         {{ if .Values.BoscoOverrides.TarballURL | default "" | contains "bosco-1.3"  }}
-        grid_resource = $(grid_resource) --rgahp-script batch_gahp
+        gr = $(gr) --rgahp-script batch_gahp
         {{ end }}
         {{ if not .Values.RemoteCluster.SSHBatchMode }}
-        grid_resource = $(grid_resource) --rgahp-nobatchmode
+        gr = $(gr) --rgahp-nobatchmode
         {{ end }}
         {{ if not .Values.RemoteCluster.LoginShell }}
-        grid_resource = $(grid_resource) --rgahp-nologin
+        gr = $(gr) --rgahp-nologin
         {{ end }}
     @jrt
     JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) GridResource
@@ -155,7 +155,8 @@ data:
     {{ if .Values.JobRouterUseTransforms }}
     JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False
     JOB_ROUTER_ROUTE_Hosted_CE_default_route @=jrt
-        GridResource = "$(grid_resource)"
+        GridResource = "dummy"
+        SET GridResource "$(gr)"
     @jrt
     {{ else }}
     JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = True


### PR DESCRIPTION
The first-class GridResource param in the new route syntax can't handle macro substitution. So set a dummy value and use SET to set the real value. Also, 'grid_resource' is set as a top-level config parameter, so avoid using it as a temporary variable in the route syntax.