### PR TITLE
HTCONDOR-2253 Fix CERequirements when default_CERequirements not set

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.7.1
+version: 4.7.2

--- a/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/configmap.yaml
@@ -152,6 +152,17 @@ data:
     @jrt
     JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) GridResource
 
+    # Fix bug in CERequirements pre transform in base CE config
+    # Bug is fixed in 23.0.X (HTCONDOR-2276)
+    JOB_ROUTER_TRANSFORM_CERequirements @=jrt
+        SET CondorCE 1
+        if defined MY.default_CERequirements
+            SET CERequirements "$(MY.default_CERequirements),CondorCE"
+        else
+            SET CERequirements "CondorCE"
+        endif
+    @jrt
+
     {{ if .Values.JobRouterUseTransforms }}
     JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False
     JOB_ROUTER_ROUTE_Hosted_CE_default_route @=jrt


### PR DESCRIPTION
This is a bug in the CERequirements post transform in base CE configuration. The wrong value is set if default_CERequirements isn't set in the route. A fix will be released in V23. Here, we apply the same fix for Hosted CEs user older HTCondor-CE versions.