### PR TITLE
osg-hosted-ce 4.7.5: clean up CE environment by not adding the *_SERVICE_* vars

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.7.4
+version: 4.7.5

--- a/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         app.kubernetes.io/part-of: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      enableServiceLinks: false
       {{ if .Values.NodeSelection.Enabled }}
       nodeSelector: 
         {{ if .Values.NodeSelection.NodeLabels}}


### PR DESCRIPTION
This keeps Kubernetes from creating several environment variables with `_SERVICE_` in the name for every single Service in the namespace.