### PR TITLE
SOFTWARE-5928: Build from external repos via build-config.json

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -77,6 +77,20 @@ jobs:
               version: 'v3.12.0'
             id: install
 
+          - name: Upstream Repo Sync
+            # if build-config.json in this chartpath specifies an external git repo,
+            # clone that repo and move its contents to chartpath
+            if: ${{ hashFiles(format('{0}/{1}',matrix.chartpath, 'build-config.json')) != '' }}
+            run: |
+              UPSTREAM=$(jq -r '.upstream' ${{matrix.chartpath}}/build-config.json)
+              TAG=$(jq -r '.tag' ${{matrix.chartpath}}/build-config.json)
+              CHART_DIR=$(jq -r '.chart_dir' ${{matrix.chartpath}}/build-config.json)
+              git clone --branch $TAG --depth 1 $UPSTREAM ${{matrix.chartpath}}/upstream
+              # Re-organize the directory so that Chart.yaml sits at the top level of ${{matrix.chartpath}}
+              # to align directory structure with remaining GHA steps
+              mv ${{matrix.chartpath}}/upstream/$CHART_DIR/* ${{matrix.chartpath}}
+              
+
           - name: Helm Chart Linter
             run: |
               helm lint ${{matrix.chartpath}}

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -83,9 +83,10 @@ jobs:
             if: ${{ hashFiles(format('{0}/{1}', matrix.chartpath, 'build-config.json')) != '' }}
             run: |
               UPSTREAM=$(jq -r '.upstream' ${{matrix.chartpath}}/build-config.json)
-              TAG=$(jq -r '.tag' ${{matrix.chartpath}}/build-config.json)
+              REF=$(jq -r '.ref' ${{matrix.chartpath}}/build-config.json)
               CHART_DIR=$(jq -r '.chart_dir' ${{matrix.chartpath}}/build-config.json)
-              git clone --branch $TAG --depth 1 $UPSTREAM ${{matrix.chartpath}}/upstream
+              git clone $UPSTREAM ${{matrix.chartpath}}/upstream
+              (cd ${{matrix.chartpath}}/upstream; git fetch && git reset --hard $REF)
               # Re-organize the directory so that Chart.yaml sits at the top level of ${{matrix.chartpath}}
               # to align directory structure with remaining GHA steps
               mv ${{matrix.chartpath}}/upstream/$CHART_DIR/* ${{matrix.chartpath}}

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -80,7 +80,7 @@ jobs:
           - name: Upstream Repo Sync
             # if build-config.json in this chartpath specifies an external git repo,
             # clone that repo and move its contents to chartpath
-            if: ${{ hashFiles(format('{0}/{1}',matrix.chartpath, 'build-config.json')) != '' }}
+            if: ${{ hashFiles(format('{0}/{1}', matrix.chartpath, 'build-config.json')) != '' }}
             run: |
               UPSTREAM=$(jq -r '.upstream' ${{matrix.chartpath}}/build-config.json)
               TAG=$(jq -r '.tag' ${{matrix.chartpath}}/build-config.json)
@@ -114,6 +114,9 @@ jobs:
               fi 
 
           - name: Helm Chart Version Check
+            # if build-config.json in this chartpath specifies an external git repo,
+            # assume that an explicit upgrade was detected and don't compare semvers
+            if: ${{ hashFiles(format('{0}/{1}', matrix.chartpath, 'build-config.json')) == '' }}
             env: 
               BASE: ${{needs.build-chart-list.outputs.BASE}}
             run: |

--- a/supported/iris-hep/kuantifier/build-config.json
+++ b/supported/iris-hep/kuantifier/build-config.json
@@ -1,5 +1,5 @@
 {
     "upstream":"https://github.com/rptaylor/kapel.git",
-    "tag": "master",
+    "ref": "8e58b78fbecdad922b32c90dcafe21ef82e6b051",
     "chart_dir": "chart"
 }

--- a/supported/iris-hep/kuantifier/build-config.json
+++ b/supported/iris-hep/kuantifier/build-config.json
@@ -1,5 +1,5 @@
 {
     "upstream":"https://github.com/rptaylor/kapel.git",
     "tag": "master",
-    "package_dir": "chart"
+    "chart_dir": "chart"
 }

--- a/supported/iris-hep/kuantifier/build-config.json
+++ b/supported/iris-hep/kuantifier/build-config.json
@@ -1,0 +1,5 @@
+{
+    "upstream":"https://github.com/rptaylor/kapel.git",
+    "tag": "master",
+    "package_dir": "chart"
+}


### PR DESCRIPTION
- Add a new GHA step that checks for the presence of a `build-config.json` file in each updated chart path
   - Uses [hashFiles expression](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/expressions#hashfiles) to check for existence of `build-config.json`
- If present, clone the specified upstream repo and reset --hard to the given commit
- Run the remainder of the GHA as normal with the cloned chart's contents present in the directory
  - skips Helm Chart Version Check since version is manually specified in `build-config.json`

https://github.com/rptaylor/kapel.git currently doesn't have any tags so use the hash of the latest commit as a starting ref