### PR TITLE
FIXME: add support for OSG 24 container images

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.11.0
+version: 4.12.0

--- a/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
@@ -116,7 +116,11 @@ spec:
       {{ end }}
       containers:
       - name: osg-hosted-ce
+        {{ if .Values.ContainerTags.HostedCE | default "" | contains "23-" }}
         image: hub.opensciencegrid.org/opensciencegrid/hosted-ce:{{ .Values.ContainerTags.HostedCE }}
+        {{ else }}
+        image: hub.opensciencegrid.org/osg-htc/hosted-ce:{{ .Values.ContainerTags.HostedCE }}
+        {{ end }}
         imagePullPolicy: Always
         volumeMounts:
         - name: osg-hosted-ce-{{ .Values.Instance }}-configuration


### PR DESCRIPTION
osg-htc is the new project going forward, remove this once all
deployments have been moved over to OSG 24