### PR TITLE
Update kuantifier to 1.3.2

### DIFF
--- a/supported/iris-hep/kuantifier/build-config.json
+++ b/supported/iris-hep/kuantifier/build-config.json
@@ -1,5 +1,5 @@
 {
     "upstream":"https://github.com/rptaylor/kuantifier.git",
-    "ref": "v1.3.0",
+    "ref": "v1.3.2",
     "chart_dir": "chart"
 }


### PR DESCRIPTION
For https://github.com/rptaylor/kuantifier/pull/80  (1.3.2)

and https://github.com/rptaylor/kuantifier/pull/78 via https://github.com/rptaylor/kuantifier/pull/79  (1.3.1) , assuming @mwestphall is okay with going straight to 1.3.2.