### PR TITLE
SOFTWARE-6149: allow for osg-configure ConfigMap propagation

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.13.1
+version: 4.14.0

--- a/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
@@ -124,8 +124,7 @@ spec:
         imagePullPolicy: Always
         volumeMounts:
         - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
-          mountPath: /tmp/90-local.ini
-          subPath: 90-local.ini
+          mountPath: /tmp/etc/osg/config.d
         {{ if .Values.ExternalHTCondorCeConfig }}
         {{- range .Values.ExternalHTCondorCeConfig }}
         - name: {{ .Name }}


### PR DESCRIPTION
Should be safe now that this has been merged:  https://github.com/opensciencegrid/docker-compute-entrypoint/pull/125