### PR TITLE
osg-hosted-ce: create Certificate object if requested (SOFTWARE-6247)

### DIFF
--- a/supported/osg-htc/osg-hosted-ce/Chart.yaml
+++ b/supported/osg-htc/osg-hosted-ce/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "V5-branch"
 description: OSG Hosted Compute Entrypoint
 name: osg-hosted-ce
-version: 4.14.0
+version: 4.15.0

--- a/supported/osg-htc/osg-hosted-ce/templates/_helpers.tpl
+++ b/supported/osg-htc/osg-hosted-ce/templates/_helpers.tpl
@@ -34,6 +34,6 @@ Default host cert/key secret name.
 {{- if .Values.HostCredentials.HostCertKeySecret -}}
 {{- .Values.HostCredentials.HostCertKeySecret -}}
 {{- else -}}
-{{ include "osg-hosted-ce.name" . }}-cert
+{{ include "osg-hosted-ce.name" . }}-gencert
 {{- end -}}
 {{- end -}}

--- a/supported/osg-htc/osg-hosted-ce/templates/_helpers.tpl
+++ b/supported/osg-htc/osg-hosted-ce/templates/_helpers.tpl
@@ -26,3 +26,14 @@ Create chart name and version as used by the chart label.
 {{- define "osg-hosted-ce.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Default host cert/key secret name.
+*/}}
+{{- define "osg-hosted-ce.certname" -}}
+{{- if .Values.HostCredentials.HostCertKeySecret -}}
+{{- .Values.HostCredentials.HostCertKeySecret -}}
+{{- else -}}
+{{ include "osg-hosted-ce.name" . }}-cert
+{{- end -}}
+{{- end -}}

--- a/supported/osg-htc/osg-hosted-ce/templates/certificate.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/certificate.yaml
@@ -17,11 +17,7 @@ spec:
   dnsNames:
     - {{ .Values.Networking.Hostname }}
   issuerRef:
-    {{- if .Values.HostCredentials.LetsEncryptStaging }}
-    name: letsencrypt-staging
-    {{- else }}
-    name: letsencrypt-prod-newchain
-    {{- end }}
-    kind: ClusterIssuer
+    name: {{ .Values.HostCredentials.CertificateIssuer }}
+    kind: {{ .Values.HostCredentials.CertificateIssuerKind }}
   secretName: {{ template "osg-hosted-ce.certname" . }}
 {{ end }}

--- a/supported/osg-htc/osg-hosted-ce/templates/certificate.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/certificate.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.HostCredentials.CreateCertificate }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: {{ template "osg-hosted-ce.name" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ template "osg-hosted-ce.certname" . }}
+spec:
+  commonName: {{ .Values.Networking.Hostname }}
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - {{ .Values.Networking.Hostname }}
+  issuerRef:
+    {{- if .Values.HostCredentials.LetsEncryptStaging }}
+    name: letsencrypt-staging
+    {{- else }}
+    name: letsencrypt-prod-newchain
+    {{- end }}
+    kind: ClusterIssuer
+  secretName: {{ template "osg-hosted-ce.certname" . }}
+{{ end }}

--- a/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
+++ b/supported/osg-htc/osg-hosted-ce/templates/deployment.yaml
@@ -83,10 +83,10 @@ spec:
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-known-hosts
       {{ end }}
-      {{ if .Values.HostCredentials.HostCertKeySecret }}
+      {{ if or .Values.HostCredentials.HostCertKeySecret .Values.HostCredentials.CreateCertificate }}
       - name: osg-hosted-ce-hostcertkey-volume
         secret:
-          secretName: {{ .Values.HostCredentials.HostCertKeySecret }}
+          secretName: {{ template "osg-hosted-ce.certname" . }}
           items:
           - key: tls.crt
             path: hostcert.pem
@@ -156,7 +156,7 @@ spec:
         - name: lib-condor-ce
           mountPath: /var/lib/condor-ce
         {{ end }}
-        {{ if .Values.HostCredentials.HostCertKeySecret }}
+        {{ if or .Values.HostCredentials.HostCertKeySecret .Values.HostCredentials.CreateCertificate }}
         - name: osg-hosted-ce-hostcertkey-volume
           mountPath: /etc/grid-security-orig.d
         {{ end }}

--- a/supported/osg-htc/osg-hosted-ce/values.yaml
+++ b/supported/osg-htc/osg-hosted-ce/values.yaml
@@ -200,20 +200,19 @@ HostCredentials:
   CreateCertificate: false
   # Set this to the name of the ClusterIssuer on your cluster for
   # creating Let's Encrypt certificates.
-  # No effect if CreateCertificate is 'false' or if LetsEncryptStaging is 'true'.
+  # No effect if CreateCertificate is 'false'.
   # The currently available issuers are:
   # 'letsencrypt-prod-newchain' (tiger); 'letsencrypt-prod-osg' (tempest);
   # 'i2-eab-issuer', 'nrp-org-cloudflare-issuer' (nautilus)
   CertificateIssuer: letsencrypt-prod-newchain
+  # Set this to ClusterIssuer or Issuer depending on whether the issuer above
+  # is cluster-wide or part of the namespace.
+  CertificateIssuerKind: ClusterIssuer
   # Name of the secret containing a host key and certificate in
   # "tls.key" and "tls.crt", respectively.
   # If CreateCertificate is 'true', but HostCertKeySecret is null,
   # a default name will be used.
   HostCertKeySecret: null
-  # If set to 'true', use the Let's Encrypt staging server. This is
-  # useful for avoiding Let's Encrypt rate limits when first setting
-  # up a CE. NOT SUITABLE FOR PRODUCTION USE.
-  LetsEncryptStaging: false
 
 # Choose which tag to use for the specified containers
 ContainerTags:

--- a/supported/osg-htc/osg-hosted-ce/values.yaml
+++ b/supported/osg-htc/osg-hosted-ce/values.yaml
@@ -196,8 +196,19 @@ NodeSelection:
 ServiceAnnotations: {}
 
 HostCredentials:
+  # If set to 'true', will create a CertManager Certificate object.
+  CreateCertificate: false
+  # Set this to the name of the ClusterIssuer on your cluster for
+  # creating Let's Encrypt certificates.
+  # No effect if CreateCertificate is 'false' or if LetsEncryptStaging is 'true'.
+  # The currently available issuers are:
+  # 'letsencrypt-prod-newchain' (tiger); 'letsencrypt-prod-osg' (tempest);
+  # 'i2-eab-issuer', 'nrp-org-cloudflare-issuer' (nautilus)
+  CertificateIssuer: letsencrypt-prod-newchain
   # Name of the secret containing a host key and certificate in
-  # "tls.key" and "tls.crt", respectively. 
+  # "tls.key" and "tls.crt", respectively.
+  # If CreateCertificate is 'true', but HostCertKeySecret is null,
+  # a default name will be used.
   HostCertKeySecret: null
   # If set to 'true', use the Let's Encrypt staging server. This is
   # useful for avoiding Let's Encrypt rate limits when first setting


### PR DESCRIPTION
Adds the `HostCredentials.CreateCertificate` boolean -- if set to true (default false) then the chart will create a certmanager `Certificate` object using the issuer specified in `HostCredentials.CertificateIssuer` (default `letsencrypt-prod-newchain` which is the Let's Encrypt issuer on tiger).

The new certificate and resulting secret will be named after `HostCredentials.HostCertKeySecret` (if specified) or `<ce name>-cert` if not specified (which matches the existing pattern).

For backward compat, if `HostCredentials.LetsEncryptStaging` is true then it will use the `letsencrypt-staging` issuer instead, ignoring `HostCredentials.CertificateIssuer`. I'm wondering if that setting is still useful though...